### PR TITLE
Replace openpyxl with XlsxWriter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openpyxl~=3.0
+xlsxwriter~=3.0
 requests~=2.27
 lxml ~= 4.9


### PR DESCRIPTION
This PR replaces openpyxl with XlsxWriter.

### Performance

Most benchmarks I can find suggest [XlsxWriter](https://pypi.org/project/XlsxWriter/) should have better performance than openpyxl, at least for writing data. (The [benchmarks](https://openpyxl.readthedocs.io/en/stable/performance.html#write-performance) on openpyxl's own documentation would suggest this, too.)

Here are some quick benchmarks from my local machine (2020 MacBook Air with a M1 processor). The difference for me is just a few seconds, so it's not quite to the level some benchmarks on the internet would suggest, but it includes parsing the daily dump as well (although excludes downloading it).

#### openpyxl
```zsh
$ for i in {1..5}; do time python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump; done      
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  18.86s user 0.63s system 96% cpu 20.231 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  19.29s user 0.43s system 98% cpu 20.087 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  18.99s user 0.96s system 98% cpu 20.201 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  19.02s user 0.60s system 99% cpu 19.678 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  18.89s user 0.76s system 98% cpu 20.018 total
```

#### XlsxWriter
```zsh
$ for i in {1..5}; do time python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump; done
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  14.06s user 0.56s system 83% cpu 17.505 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  14.18s user 0.53s system 86% cpu 16.935 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  14.10s user 0.55s system 85% cpu 17.221 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  13.95s user 0.43s system 86% cpu 16.557 total
Saving spreadsheet...
python spyglass.py -n esfalsa --minor 3550 --major 5350 --dump  14.03s user 0.48s system 87% cpu 16.656 total
```

XlsxWriter apparently uses less CPU as well, but I didn't really find that advertised as a benefit much from my internet searches so it might have just been a fluke with whatever else was running on my computer at the time.

### File Size
Incidentally, XlsxWriter seems to produce a smaller output file as well, at least for today's daily dump.

#### openpyxl
```zsh
$ stat -f '%z' spyglass2023-4-1.xlsx                            
7520100
```

#### XlsxWriter
```zsh
$ stat -f '%z' spyglass2023-4-1.xlsx
6482421
```