### PR TITLE
Raise requests error on HTTP error code

### DIFF
--- a/spyglass.py
+++ b/spyglass.py
@@ -18,7 +18,7 @@ import logging
 # Yay more modifications & V3 rewrite (Aav)
 
 # UPDATE THIS EVERY TIME A NEW RELEASE IS PACKAGED
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 
 # Color declarations because OpenPyXL removed them :^)
 RED = Color(rgb="FFFF0000")

--- a/spyglass.py
+++ b/spyglass.py
@@ -187,9 +187,10 @@ logger.info("Session constructed")
 
 # Ensure that this nation actually exists
 try:
-    session.get(
+    req = session.get(
         f"https://www.nationstates.net/cgi-bin/api.cgi?nation={nation}&q=region"
     )
+    req.raise_for_status()
 except HTTPError:
     logger.error("Nation does not exist.")
     print("The provided nation does not exist... terminating.")


### PR DESCRIPTION
Spyglass wasn't properly checking if the user's nation didn't exist, at least on my local machine; this PR should resolve those issues.

Relevant:
* https://stackoverflow.com/questions/16511337/correct-way-to-try-except-using-python-requests-module#comment65361103_16511493
* https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status