### PR TITLE
Download dump in CLI mode if not found

### DIFF
--- a/spyglass.py
+++ b/spyglass.py
@@ -236,6 +236,10 @@ else:
         else:
             download_dump(session)
             logger.info("Download complete!")
+    else:
+        logger.info("No existing data dump found, downloading latest...")
+        download_dump(session)
+        logger.info("Download complete!")
 
 # Get the lists of founderless and passwordless regions
 logger.info("Getting founderless regions...")


### PR DESCRIPTION
Currently, when run in non-interactive mode, Spyglass seems to skip over downloading the latest data dump if it doesn't already exist, which leads to a `FileNotFoundError` when it then tries to `gzip.open` that file. This PR automatically downloads the latest dump if none is found when Spyglass is run in non-interactive mode.

I was going to file a bug report for this, but the code change turned out pretty small 😛. Also sorry if this steps on your toes with respect to daily dump download error handling (#33), though I think you were referring to handling errors with the download request/response, while this deals with errors with CLI arguments provided by the user?